### PR TITLE
WiFi warning and link.

### DIFF
--- a/sphinx/users/networking.rst
+++ b/sphinx/users/networking.rst
@@ -30,6 +30,9 @@ layers of the networking stack including:
 * Masquerading
 * open ports for applications.
 
+.. warning:: Connecting to a wireless network is not yet automated. See
+   `WiFi on UBOS <http://ubos.net/blog/2016/08/18/wifi.html>`.
+
 Currently available network configurations
 ------------------------------------------
 


### PR DESCRIPTION
Warn that WiFi is not yet automated, and link to the blog post about it.